### PR TITLE
Second attempt at fixing Iris dataset

### DIFF
--- a/server.R
+++ b/server.R
@@ -56,6 +56,14 @@ server <- function(input, output, session) {
            col = input$color,
            border = "white")
     }
+    else if(input$dataset == "iris") {
+      hist(data[[input$variable]], 
+           breaks = input$bins,
+           main = paste("Distribution of", input$variable),
+           xlab = input$variable,
+           col = input$color,
+           border = "white")
+    }
     # MISSING: iris dataset case - this causes the crash!
     # Students need to add the iris case or make it generic
   })


### PR DESCRIPTION
### Summary
Fixed the issue of the Iris Flowers dataset selection crashing the app by creating a further else if section to the histogram code.

### Current state
When trying to load the histogram of the Iris Flowers dataset, the app crashes.

### Proposed changes
The hist section of the code is missing an option for the "iris" dataset, so the proposed change is to add one.

### Implementation Steps
- [x]  Copy the else if section from the hist part of the server.R code and paste it directly under itself.
- [x]  Replace the dataset with "iris".
- [x]  Make sure brackets are in the right place.
- [x]  Save the code.

### Checklist of specific tasks to complete
- [x]  Heather - Fix the code by following the implementation steps above.
- [ ]  Maddie - Check the code works by following the verification steps below.
- [ ]  Accept the pull request.

### How to verify the work is complete
- [ ]  Run the app
- [ ]  Select the Iris Flowers dataset
- [ ]  If a histogram appears and its bar lengths and widths can be changed using the sliders, then we are done.